### PR TITLE
add support for the RHUI-in-a-box deployment

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -134,6 +134,20 @@ argument. The file can be specified the following ways:
 
 The deployment fails if the `--answers` argument is used with a file that does not exist.
 
+RHUI-in-a-box
+-------------
+As described in the README file for the stack creation script, a compact RHUI environment with
+a single VM for the RHUA and CDS containers can exist. To run this deployment, you need an answers
+file with `cds_combo: True`. If you have `answers.yaml` with this option in your RHUI directory,
+no special argument for the answers file is needed. Or you can create such an answers file with any
+name and specify it as described above. Either way, the `--boxed` argument is needed on the
+`deploy.py` command line.
+
+> [!IMPORTANT]
+> The test suite can not run in this environment, unless you skip the steps that work with CDS
+> and/or HAProxy nodes. However, you can add or create repos, build configuration RPMs and install
+> them on client VMs, and you _should_ get content.
+
 Managed roles
 -------------
 - RHUA

--- a/deploy/launchpad.yml
+++ b/deploy/launchpad.yml
@@ -28,7 +28,9 @@
       {% else %}
       --target-host rhua.example.com
       --remote-fs-server nfs.example.com:/export
+      {% if not boxed | default(False) %}
       --cds-lb-hostname lb.example.com
+      {% endif %}
       {% endif %}
       {% if not saveandrestore | default(False) %}
       --rhua-container-registry {{ registry['hostname'] }}

--- a/deploy/roles/launchpad/tasks/main.yml
+++ b/deploy/roles/launchpad/tasks/main.yml
@@ -163,16 +163,16 @@
   when: ansible_distribution in distros_that_need_docker
   tags: launchpad,reinstall
 
-- name: wait for the RHUA service to start listening on port 443
+- name: wait for the RHUA service to start listening on its API port
   wait_for:
     host: "{{ 'another' if toanotherrhua | default(False) else '' }}rhua.example.com"
-    port: 443
+    port: "{{ 8443 if boxed | default(False) else 443 }}"
     delay: "{{ 45 if mig | default(False) else 10 }}"
   tags: launchpad,reinstall
 
 - name: wait a bit more before checking rhui-manager
   pause:
-    minutes: 1
+    minutes: "{{ 2 if boxed | default(False) else 1 }}"
   tags: launchpad,reinstall
 
 - name: move the directory with test files back after cloning
@@ -193,6 +193,11 @@
 - name: print the output from rhui-manager
   debug:
     var: rhuimanagercmd.stdout_lines
+  tags: launchpad,reinstall
+
+- name: print any error output from rhui-manager
+  debug:
+    var: rhuimanagercmd.stderr_lines
   tags: launchpad,reinstall
 
 - import_tasks: ssh_post.yml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -166,6 +166,11 @@ Usage example:
 ./scripts/create-cf-stack.py --launchpad-ami ami-002c5f307df891b6b --launchpad-user fedora --name rhuifromf42
 ```
 
+### RHUI-in-a-box
+RHUI can be deployed in a special mode where the CDS container is running together with the RHUA
+container on the RHUA node, and no dedicated CDS and HAProxy VMs are needed. To launch only the VMs
+for the launchpad and the RHUA, use the `--boxed` argument of the stack creation script.
+
 ### How to delete stack
 
 Stack can be deleted "all in one" with CloudFormation. On the AWS amazon web page go to the

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -55,7 +55,7 @@ PRS.add_argument("--credentials",
                  metavar="file")
 PRS.add_argument("--answers",
                  help=f"optional answers file; an absolute path, or a file in {RHUI_DIR}, or " \
-                      f"'_' as an alias for anwswers.yaml in {RHUI_DIR}",
+                      f"'_' as an alias for answers.yaml in {RHUI_DIR}",
                  metavar="file")
 PRS.add_argument("--tests",
                  help="RHUI test to run",
@@ -93,6 +93,10 @@ PRS.add_argument("--mig",
                  action="store_true")
 PRS.add_argument("--toanotherrhua",
                  help="make the migration from RHUI 4 to 5 non-in-place (to another RHUA)",
+                 action="store_true")
+PRS.add_argument("--boxed",
+                 help="prepare for a 'RHUI-in-a-box' deployment - RHUA and CDS on the same host; \
+                       still requires an answers file with cds_combo: True (see `--answers')",
                  action="store_true")
 PRS.add_argument("--dry-run",
                  help="only construct and print the ansible-playbook command, do not run it",
@@ -150,6 +154,13 @@ else:
     print(ARGS.extra_files + " does not exist, ignoring")
 
 EVARS += " credentials=" + ARGS.credentials
+
+if ARGS.boxed:
+    # set related options accordingly as some are mutually exclusive and others may be implied
+    ARGS.clone = ARGS.mig = False
+    if not ARGS.answers:
+        ARGS.answers = "_"
+    EVARS += " boxed=True"
 
 if ARGS.answers:
     if ARGS.answers.startswith("/"):

--- a/tests/rhui5_tests/test_client_management.py
+++ b/tests/rhui5_tests/test_client_management.py
@@ -321,7 +321,7 @@ class TestClient():
         Expect.expect_retval(CLI, "yum clean all ; yum -v repolist enabled")
         Expect.expect_retval(CDS,
                              f"egrep 'Found file {LEGACY_CA_DIR}/{LEGACY_CA_FILE}' " +
-                             "/var/lib/rhui/log/gunicorn-auth.log")
+                             "/var/lib/rhui/cds/log/gunicorn-auth.log")
 
     def test_99_cleanup(self):
         '''

--- a/tests/rhui5_tests_lib/cfg.py
+++ b/tests/rhui5_tests_lib/cfg.py
@@ -6,7 +6,7 @@ from stitches.expect import Expect
 
 RHUI_CFG_STATIC = "/etc/rhui-static/rhui-tools-static.conf"
 RHUI_CFG_CUSTOM = "/etc/rhui/rhui-tools.conf"
-RHUI_CFG_HOST = "/var/lib/rhui/config/rhu?/rhui-tools.conf"
+RHUI_CFG_HOST = "/var/lib/rhui/*/*/rhui-tools.conf"
 RHUI_CFG_HOST_BAK_DIR = "/var/lib/rhui/root"
 
 RHUI_ROOT = "/var/lib/rhui/remote_share"


### PR DESCRIPTION
These changes are only on the deployment side. Test cases that attempt to add a CDS wouldn't work in this scenario. Still, one could do:

On the test node, bootstrap the environment with test repos and configure the client:

1. rhui-test-setup --cert-only
2. export RHUISKIPSETUP=1
3. export RHUIPREP=1
4. rhuitests client_management

On the client node, run some commands that communicate with the boxed RHUI:

1. yum -v repolist
2. yumdownloader '*'

Here's an example of an answers file, which can (but doesn't have to) exist in the parent directory:

```
rhua:
  rhui_manager_password: admin123456
  pulp_workers: 4
  cds_combo: True
```